### PR TITLE
Fixes to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /Debug/
 /Release/
-
+_build/
 /doc/
 /logs/
 /Debug52/

--- a/makefile
+++ b/makefile
@@ -15,7 +15,14 @@ TEMPLATE_PATH := $(COMPONENTS)/toolchain/gcc
 EHAL_PATH     := $(HOME)/nrf/sdk/ehal_latest
 LINKER_SCRIPT := ./linker/gcc_nrf51_s130_32kb.ld
 OUTPUT_NAME   := FruityMesh
-JLINK	      := jlinkexe
+
+OS := $(shell uname -s)
+ifeq ($(OS),Darwin)
+  JLINK 	:= jlinkexe
+else
+  JLINK		:= jlink
+endif
+
 
 #------------------------------------------------------------------------------
 # Proceed cautiously beyond this point.  Little should change.


### PR DESCRIPTION
These commits:
- Change the makefile's behaviour for debug/release builds.
Prior to this, makefile had -DDEBUG on always; now this is contingent on specifically requesting a debug build thus:

```
MAKECMDGOALS=debug make debug
```
- Refactored Makefile to TARGET_BOARD macro
- Adds 'flash' goal to makefile
- Modifies .gitignore to ignore _build/ artefacts
- Adds -D ENABLE_LOGGING by default
- Adds -D DEST_BOARD_ID for modules to use when communicating over the mesh. Default is 0 (broadcast)
- Minor cosmetics
