### PR TITLE
Fixed undefined behavior bug and a possible pitfall for HAL developers

### DIFF
--- a/cherrysim/CherrySim.cpp
+++ b/cherrysim/CherrySim.cpp
@@ -1953,6 +1953,7 @@ void CherrySim::BootCurrentNode()
     u32* halMemory = new u32[halMemorySize];
     CheckedMemset(halMemory, 0, halMemorySize * sizeof(u32));
     GS->halMemory = halMemory;
+    FruityHal::InitHalMemory();
 
     //############## Boot the node using the FruityMesh boot routine
     BootFruityMesh();

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -36,6 +36,7 @@ int main(void)
     DYNAMIC_ARRAY(halMemory, FruityHal::GetHalMemorySize());
     CheckedMemset(halMemory, 0, FruityHal::GetHalMemorySize());
     GS->halMemory = halMemory;
+    FruityHal::InitHalMemory();
     
     BootFruityMesh();
     GS->fruityMeshBooted = true;

--- a/src/hal/FruityHal.h
+++ b/src/hal/FruityHal.h
@@ -527,6 +527,7 @@ namespace FruityHal
     void GetDeviceAddress(u8 * p_address);
 
     u32 GetHalMemorySize();
+    void InitHalMemory();
 
     // ######################### Timeslot API ############################
 

--- a/src/hal/nrf/FruityHalNrf.cpp
+++ b/src/hal/nrf/FruityHalNrf.cpp
@@ -136,28 +136,29 @@ struct GpioteHandlerValues
 
 struct NrfHalMemory
 {
-    std::array <app_timer_t, APP_TIMER_MAX_TIMERS> swTimers;
-    ble_db_discovery_t discoveredServices;
-    volatile bool twiXferDone;
-    bool twiInitDone;
-    volatile bool spiXferDone;
-    bool spiInitDone;
-    volatile bool nrfSerialDataAvailable = false;
-    volatile bool nrfSerialErrorDetected = false;
-    bool overflowPending;
-    u32 time_ms;
-    GpioteHandlerValues GpioHandler[MAX_GPIOTE_HANDLERS];
-    u8 gpioteHandlersCreated;
-    ble_evt_t const * currentEvent;
-    u8 timersCreated;
+    std::array <app_timer_t, APP_TIMER_MAX_TIMERS> swTimers                   = {};
+    ble_db_discovery_t discoveredServices                                     = {};
+    volatile bool twiXferDone                                                 = false;
+    bool twiInitDone                                                          = false;
+    volatile bool spiXferDone                                                 = false;
+    bool spiInitDone                                                          = false;
+    volatile bool nrfSerialDataAvailable                                      = false;
+    volatile bool nrfSerialErrorDetected                                      = false;
+    bool overflowPending                                                      = false;
+    u32 time_ms                                                               = 0;
+    GpioteHandlerValues GpioHandler[MAX_GPIOTE_HANDLERS]                      = {};
+    u8 gpioteHandlersCreated                                                  = 0;
+    ble_evt_t const * currentEvent                                            = nullptr;
+    u8 timersCreated                                                          = 0;
 #if SDK == 15
-    ble_gap_adv_data_t advData;
+    ble_gap_adv_data_t advData                                                = {};
 #endif
 #if IS_ACTIVE(TIMESLOT)
-    nrf_radio_signal_callback_return_param_t timeslotRadioCallbackReturnParam;
-    nrf_radio_request_t timeslotRadioRequest;
+    nrf_radio_signal_callback_return_param_t timeslotRadioCallbackReturnParam = {};
+    nrf_radio_request_t timeslotRadioRequest                                  = {};
 #endif // IS_ACTIVE(TIMESLOT)
 };
+static_assert(alignof(NrfHalMemory) <= 4, "The HAL Memory is allocated in a memory block with an alignment of 4. Thus the alignment must not be greater!");
 
 //#################### Event Buffer ###########################
 //A global buffer for the current event, which must be 4-byte aligned
@@ -3868,6 +3869,11 @@ void FruityHal::SpiConfigureSlaveSelectPin(i32 pin)
 u32 FruityHal::GetHalMemorySize()
 {
     return sizeof(NrfHalMemory);
+}
+
+void FruityHal::InitHalMemory()
+{
+    new (GS->halMemory) NrfHalMemory();
 }
 
 #if IS_ACTIVE(TIMESLOT)


### PR DESCRIPTION
The HAL memory is located on the stack as an array of u8. Previously it was interpreted as a HAL Memory Object without creating it properly. This is a violation of the strict aliasing rule. Problems with this did not happen on GCC previously because FruityMesh is using -fno-strict-aliasing. However, even with this setting it opened a pitfall for HAL developers that assumed they could initialize members inside the struct definition, like:

```
struct NrfHalMemory
{
    //...
    volatile bool nrfSerialDataAvailable = false;
    volatile bool nrfSerialErrorDetected = false;
    //...
};
```
(actual code on current master!). This was wrong and has never worked that way. Now it does. Now the object is constructed properly with placement new and the member initialization within the struct definition has the intended effect. This also solves potential UB bugs on other compilers like MSVC.

**NOTE:** I currently don't have the NRF Toolchain setup correctly and thus did not compile it on GCC. Careful testing is thus required.

**NOTE:** I did not adjust the template hal (fruitymesh\src\hal\template\FruityHalTemplate.cpp) because it seems to be out of date (could not find GetHalMemorySize in it.). The proper implementation for the FruityHalTemplate would be a noop.