### PR TITLE
docker container for the mesh simulator

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV TZ=Europe/Berlin
+RUN apt-get update
+
+# bluerange mesh dependencies
+RUN apt-get install -qqy git python3 python3-pip cmake gcc g++ libncurses5-dev build-essential
+
+# emd sdk dependencies 
+RUN apt-get install -qqy clang zlib1g zlib1g-dev llvm python
+RUN pip3 install requests
+
+WORKDIR /opt
+RUN git clone https://github.com/emscripten-core/emsdk.git
+WORKDIR /opt/emsdk
+
+# 3.1.74 results in build errors
+RUN git checkout 2.0.33
+
+RUN ./emsdk install latest
+RUN ./emsdk activate latest
+
+RUN echo "source /opt/emsdk/emsdk_env.sh" >> ~/.bashrc
+
+# necessary for 'source' to work
+SHELL ["/bin/bash", "-c"]
+
+COPY . /opt/bluerange-mesh
+
+RUN mkdir -p /opt/bluerange-mesh/build/linux
+WORKDIR /opt/bluerange-mesh/build
+
+RUN source /opt/emsdk/emsdk_env.sh && emcmake cmake ../ -DBUILD_TYPE=SIMULATOR -DFM_NATIVE_RENDERER_ENABLED=ON
+RUN source /opt/emsdk/emsdk_env.sh && cmake --build . --target cherrySim_runner
+RUN source /opt/emsdk/emsdk_env.sh && make -j 8
+
+ENTRYPOINT ["bash", "-c", "python3 /opt/bluerange-mesh/build/Server.py"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+# Run the simulator in a docker container
+
+## Setup
+
+### Building the image
+Simply run ```docker compose build``` to build the docker image.
+
+### Running the container
+Run ```docker compose up -d```. Please make sure that port 8000 is free. Alternatively, configure a different port in the docker compose file.
+
+## How to use the image
+After you've built the image and started the container, you can access the server in your local browser with [0.0.0.0:8000](0.0.0.0:8000). However, an error will appear telling you that an exception was thrown. Further investigation shows that your brower is blocking ```SharedArrayBuffer``` for security reasons.
+
+To solve this issue, you can try to host the server (container) with ssl encryption active. This should solve the issue but I haven't tried this. The easier solution is run chrome with SharedArrayBuffer enabled. 
+
+On linux, install Google chrome first and then run
+```bash
+google-chrome --enable-features=SharedArrayBuffer
+```
+
+Now, you can access again [0.0.0.0:8000](0.0.0.0:8000) and the simulation should start.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  bluerange-simulator:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    restart: unless-stopped
+    container_name: bluerange-simulator
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
Here's a docker container for the mesh simulator.  This includes emscripten which allows to run the server in your browers.

Please check the readme.md. 

Let me know if any changes are requested.

